### PR TITLE
Fix FDICnet medium-priority main-menu issues #5-#10

### DIFF
--- a/sites/fdicnet-main-menu/script.js
+++ b/sites/fdicnet-main-menu/script.js
@@ -546,9 +546,13 @@ function setupEvents() {
   });
 
   document.addEventListener("pointerdown", (event) => {
-    if (menuOpen && !header.contains(event.target)) {
-      closeMenu();
-    }
+    if (!menuOpen || !(event.target instanceof HTMLElement)) return;
+    if (megaMenu.contains(event.target)) return;
+
+    const navButton = event.target.closest(".fdic-nav-item--button");
+    if (navButton && navList.contains(navButton)) return;
+
+    closeMenu();
   });
 
   document.addEventListener("keydown", (event) => {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -53,3 +53,9 @@ Use this file to record correction-driven learning.
 - Root cause: L1 activation re-rendered menu columns and replaced the focused element without explicitly restoring keyboard focus.
 - Prevention rule: Any keyboard-activatable control that triggers re-render must restore focus to a deterministic target immediately after render.
 - Actionable check for future tasks: Add a keyboard regression step for `Enter` and `Space` activation on each roving item and verify visible focus remains on the same item (or an intentional next target).
+
+- Date: 2026-03-08
+- Trigger / correction: User reported that clicking header areas outside top-level menu items did not close the open menu.
+- Root cause: Global pointer close logic only handled clicks outside the entire header, so in-header non-menu clicks were excluded.
+- Prevention rule: For click-off behavior, define explicit keep-open targets and close on all other pointer targets.
+- Actionable check for future tasks: Add a pointer regression pass covering four zones: top-nav button, mega-menu panel, header non-menu controls, and page body.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,19 @@
 # TODO
 
+## Current Task (FDICnet Header Click-Off Menu Close Behavior)
+- [x] Reproduce click-off behavior where header clicks outside top-level menu items fail to close open mega menu.
+- [x] Update pointer handler to close menu for non-menu-button header clicks while preserving menu-button and mega-panel interactions.
+- [x] Run syntax validation and record verification.
+
+## Review / Results (FDICnet Header Click-Off Menu Close Behavior)
+- Updated `sites/fdicnet-main-menu/script.js`:
+  - refined document `pointerdown` close logic:
+    - keep menu open for clicks inside `#megaMenu`
+    - keep menu open for clicks on `.fdic-nav-item--button`
+    - close menu for all other clicks, including header clicks off top-level menu items
+- Verification:
+  - `node --check sites/fdicnet-main-menu/script.js`
+
 ## Current Task (FDICnet L1 Space Activation Focus Persistence)
 - [x] Reproduce and isolate focus-loss path when activating L1 item via keyboard (`Space`).
 - [x] Preserve focus on the selected L1 control after L1/L2/L3 re-render on activation.


### PR DESCRIPTION
## Summary
This PR addresses all currently open **medium-priority** issues for `fdicnet-main-menu`:
- #5 L2 active state not exposed to assistive technology
- #6 noisy `aria-current="false"` on non-current L1 items
- #7 duplicated `l2Overview` construction in `renderL2` / `renderL3`
- #8 unnecessary `renderTopNav()` full re-render on panel switch
- #9 no startup null guards for required DOM elements
- #10 dead `overviewDescription` fallback path

## Implementation
- Added `getMissingRequiredElements()` and an early-init guard in `init()` that logs explicit missing element IDs and aborts cleanly.
- Replaced panel-switch `renderTopNav()` call with `syncTopNavState()` + `applyTopNavRoving()` to avoid unnecessary nav DOM rebuilds.
- Updated L1 ARIA semantics so only the selected item has `aria-current="true"`; non-selected items no longer set `aria-current="false"`.
- Updated L2 ARIA semantics so the active L2 item exposes `aria-current="true"`.
- Updated `focusActiveL2()` to target ARIA current state.
- Extracted shared `getL2Overview(selectedL1)` helper and reused it in both `renderL2()` and `renderL3()`.
- Removed dead `selectedL1?.overviewDescription` fallback and aligned fallback behavior with the current YAML schema.

## Follow-up Fix (Keyboard Focus)
- Addressed a regression where pressing `Space` on an L1 item caused focus to disappear after re-render.
- Updated `setSelectedL1` to support `restoreFocus` and restore focus to the selected L1 item after L1/L2/L3 render updates.
- Wired L1 activation path to call `setSelectedL1(index, { restoreFocus: true })`.

## Issue plan comments
- #5: https://github.com/jflamb/pens-github-test/issues/5#issuecomment-4020170132
- #6: https://github.com/jflamb/pens-github-test/issues/6#issuecomment-4020170154
- #7: https://github.com/jflamb/pens-github-test/issues/7#issuecomment-4020170182
- #8: https://github.com/jflamb/pens-github-test/issues/8#issuecomment-4020170203
- #9: https://github.com/jflamb/pens-github-test/issues/9#issuecomment-4020170220
- #10: https://github.com/jflamb/pens-github-test/issues/10#issuecomment-4020170237

## Verification
- `node --check sites/fdicnet-main-menu/script.js`
- Targeted source checks for:
  - `getL2Overview` helper usage in both render paths
  - removal of `overviewDescription` references
  - removal of `aria-current="false"` assignment pattern
  - L2 active-focus targeting using `.l2-item[aria-current="true"]`
  - L1 `Space` activation preserving visible focus on selected item

Closes #5
Closes #6
Closes #7
Closes #8
Closes #9
Closes #10
