### PR TITLE
Fix fdicnet issue #26: use aria-selected in L2 sync

### DIFF
--- a/sites/fdicnet-main-menu/script.js
+++ b/sites/fdicnet-main-menu/script.js
@@ -508,11 +508,7 @@ function syncL2ActiveState() {
     const itemIndex = Number(item.dataset.index);
     const isActive = Number.isFinite(itemIndex) && itemIndex === activeIndex;
     item.dataset.active = isActive ? "true" : "false";
-    if (isActive) {
-      item.setAttribute("aria-current", "true");
-    } else {
-      item.removeAttribute("aria-current");
-    }
+    item.setAttribute("aria-selected", isActive ? "true" : "false");
   });
 }
 
@@ -584,7 +580,6 @@ function renderL1() {
   const rovingIndex = Math.max(0, Math.min(menuState.l1FocusIndex, maxRovingIndex));
   menuState.l1FocusIndex = rovingIndex;
   l1List.innerHTML = "";
-  const l1Items = getPanelL1();
 
   l1Items.forEach((l1Item, index) => {
     const li = document.createElement("li");


### PR DESCRIPTION
## Summary
- replaces remaining L2 `aria-current` usage with `aria-selected` in `syncL2ActiveState()`
- keeps explicit true/false selected-state exposure for listbox options
- removes duplicate `const l1Items` declaration in `renderL1()` to restore clean syntax validation

## Verification
- `node --check sites/fdicnet-main-menu/script.js`
- `rg -n "aria-current" sites/fdicnet-main-menu/script.js sites/fdicnet-main-menu/index.html sites/fdicnet-main-menu/styles.css` returns no matches

Closes #26
